### PR TITLE
Sets Semantic HTML section and adds note on buttons

### DIFF
--- a/accessibility.md
+++ b/accessibility.md
@@ -18,10 +18,13 @@
 
 **[⬆ back to top](#table-of-contents)**
 
-## Document Outline
+## Semantic HTML
 
-  <a name="documentOutline--definition"></a><a name="2.1"></a>
-  - [2.1](#documentOutline--definition) Use semantic headings and structure
+  <a name="semanticHtml--definition"></a><a name="2.1"></a>
+  - [2.1](#semanticHtml--definition) Use semantic headings and structure to [establish a document outline](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines). Current consensus recommends using H1-6 heading rank rather than repeated H1 tags in nested sectioning elements.
+  <a name="semanticHtml--buttons"></a><a name="2.1"></a>
+  - [2.2](#semanticHtml--buttons) Use the `button` element for clickable JS interaction points and similar non-linking components. If not of the `submit`, `reset`, or `menu` types, use `type="button"` to designate a generic button.
+    - The `a` tag should only be used when using the `href` attribute to link "to other web pages, files, locations within the same page, email addresses, or any other URL" ([ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)).
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/accessibility.md
+++ b/accessibility.md
@@ -4,7 +4,7 @@
 
 ## Table of Contents
   1. [Language Attribute](#language-attribute)
-  2. [Document Outline](#document-outline)
+  2. [Semantic HTML](#semantic-html)
   3. [Wayfinding](#wayfinding)
   4. [Images](#images)
   5. [ARIA](#aria)
@@ -23,7 +23,7 @@
   <a name="semanticHtml--definition"></a><a name="2.1"></a>
   - [2.1](#semanticHtml--definition) Use semantic headings and structure to [establish a document outline](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines). Current consensus recommends using H1-6 heading rank rather than repeated H1 tags in nested sectioning elements.
   <a name="semanticHtml--buttons"></a><a name="2.1"></a>
-  - [2.2](#semanticHtml--buttons) Use the `button` element for clickable JS interaction points and similar non-linking components. If not of the `submit`, `reset`, or `menu` types, use `type="button"` to designate a generic button.
+  - [2.2](#semanticHtml--buttons) Use the `button` element for JS interaction points and similar non-linking components. If a button is not of the `submit`, `reset`, or `menu` types, use `type="button"` to designate a generic button.
     - The `a` tag should only be used when using the `href` attribute to link "to other web pages, files, locations within the same page, email addresses, or any other URL" ([ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)).
 
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
Resolves #65 

Changed Document Outline section to "Semantic HTML" and added a note about proper use of `button` vs `a`.